### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Here is how you set up an Expo app to be able to code in TypeScript instead of J
 Add TypeScript and the helpers library, `tslib`, to the project. It's optional to use the --exact switch. I just prefer micro managing the version of the packages that I'm using. You can, of course, also use `npm` instead of `yarn`.
 
 ```shell
-yarn add --dev --exact TypeScript react-native-typescript-transformer
+yarn add --dev --exact typescript react-native-typescript-transformer
 yarn add --exact tslib
 ```
 


### PR DESCRIPTION
Tried to install referring to readme.
At that time, the following error occurred. 

```
$ yarn add --dev --exact TypeScript
yarn add v1.6.0
info No lockfile found.
[1/4] 🔍  Resolving packages...
error An unexpected error occurred: "https://registry.yarnpkg.com/TypeScript: Not found".
info If you think this is a bug, please open a bug report with the information provided in "/Users/symmt/Program/Study/ReactNative/Expo/expo-and-typescript/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

So, fix `TypeScript` to `typescript` :)