### PR TITLE
Bar code scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ When upgrading Expo, `expo-cli` will also upgrade the versions of all the packag
 | expo-font                           | Known  | Used by FontScreen.                              |
 | expo-linear-gradient                | Known  | Used by LinearGradientScreen.                    |
 | expo-local-authentication           | Known  | Used by LocalAuthenticationScreen.               |
-| expo-permissions                    | Known  | Used by BarCodeScannerScreen and CameraScreen.   |
 | expo-sensors                        | Known  | TODO: Where is this used?                        |
 | react                               | Known  |                                                  |
 | react-native                        | Known  |                                                  |

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "expo-font": "~9.1.0",
     "expo-linear-gradient": "~9.1.0",
     "expo-local-authentication": "~11.0.2",
-    "expo-permissions": "~12.0.1",
     "expo-sensors": "~10.1.2",
     "react": "16.13.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-41.0.0.tar.gz",

--- a/src/demoScreens/BarCodeScannerScreen.tsx
+++ b/src/demoScreens/BarCodeScannerScreen.tsx
@@ -49,7 +49,6 @@ export class BarCodeScannerScreen extends React.Component<Props, State> {
             </Text>
             <View style={{ flex: 1 }}>
               <BarCodeScanner
-                barCodeTypes={[BarCodeScanner.Constants.BarCodeType.qr]}
                 onBarCodeScanned={this.handleBarCodeScanned}
                 style={StyleSheet.absoluteFill}
               />

--- a/src/demoScreens/BarCodeScannerScreen.tsx
+++ b/src/demoScreens/BarCodeScannerScreen.tsx
@@ -61,7 +61,7 @@ export class BarCodeScannerScreen extends React.Component<Props, State> {
 
   private handleBarCodeScanned = (event: { type: string; data: string }) => {
     this.setState({
-      scannedText: `A bar code of type ${event.type} with content '${event.data}' has been scanned.`,
+      scannedText: `Scanned a code of type ${event.type} with the content '${event.data}'.`,
     });
   };
 }

--- a/src/demoScreens/BarCodeScannerScreen.tsx
+++ b/src/demoScreens/BarCodeScannerScreen.tsx
@@ -29,7 +29,7 @@ export class BarCodeScannerScreen extends React.Component<Props, State> {
   public render(): ReactNode {
     switch (this.state.cameraPermission) {
       case undefined:
-        return <Text>Requesting for camera permission.</Text>;
+        return <Text>Requesting permission to access camera.</Text>;
 
       case PermissionStatus.UNDETERMINED:
         return <Text>Could not determine if camera could be accessed.</Text>;

--- a/src/demoScreens/BarCodeScannerScreen.tsx
+++ b/src/demoScreens/BarCodeScannerScreen.tsx
@@ -45,7 +45,7 @@ export class BarCodeScannerScreen extends React.Component<Props, State> {
                 margin: 10,
               }}
             >
-              this.state.scannerStatus
+              {this.state.scannedText}
             </Text>
             <View style={{ flex: 1 }}>
               <BarCodeScanner

--- a/src/demoScreens/BarCodeScannerScreen.tsx
+++ b/src/demoScreens/BarCodeScannerScreen.tsx
@@ -1,5 +1,4 @@
 import { BarCodeScanner } from "expo-barcode-scanner";
-import * as Permissions from "expo-permissions";
 import React, { ReactNode } from "react";
 import { StyleSheet, Text, View } from "react-native";
 
@@ -27,7 +26,7 @@ export class BarCodeScannerScreen extends React.Component<Props, State> {
   }
 
   public async componentDidMount() {
-    const { status } = await Permissions.askAsync(Permissions.CAMERA);
+    const { status } = await BarCodeScanner.requestPermissionsAsync();
     this.setState({
       cameraPermission:
         status === "granted" ? PermissionState.Granted : PermissionState.Denied,

--- a/src/demoScreens/BarCodeScannerScreen.tsx
+++ b/src/demoScreens/BarCodeScannerScreen.tsx
@@ -20,9 +20,9 @@ export class BarCodeScannerScreen extends React.Component<Props, State> {
   }
 
   public async componentDidMount() {
-    const { status } = await BarCodeScanner.requestPermissionsAsync();
+    const permissionResponse = await BarCodeScanner.requestPermissionsAsync();
     this.setState({
-      cameraPermission: status,
+      cameraPermission: permissionResponse.status,
     });
   }
 

--- a/src/demoScreens/BarCodeScannerScreen.tsx
+++ b/src/demoScreens/BarCodeScannerScreen.tsx
@@ -1,17 +1,11 @@
-import { BarCodeScanner } from "expo-barcode-scanner";
+import { BarCodeScanner, PermissionStatus } from "expo-barcode-scanner";
 import React, { ReactNode } from "react";
 import { StyleSheet, Text, View } from "react-native";
 
 interface Props {}
 
-enum PermissionState {
-  Unknown,
-  Denied,
-  Granted,
-}
-
 interface State {
-  cameraPermission: PermissionState;
+  cameraPermission: PermissionStatus;
   scannedText: string;
 }
 
@@ -20,7 +14,7 @@ export class BarCodeScannerScreen extends React.Component<Props, State> {
     super(props);
 
     this.state = {
-      cameraPermission: PermissionState.Unknown,
+      cameraPermission: PermissionStatus.UNDETERMINED,
       scannedText: "Scan a bar code or a QR code.",
     };
   }
@@ -29,19 +23,21 @@ export class BarCodeScannerScreen extends React.Component<Props, State> {
     const { status } = await BarCodeScanner.requestPermissionsAsync();
     this.setState({
       cameraPermission:
-        status === "granted" ? PermissionState.Granted : PermissionState.Denied,
+        status === PermissionStatus.GRANTED
+          ? PermissionStatus.GRANTED
+          : PermissionStatus.DENIED,
     });
   }
 
   public render(): ReactNode {
     switch (this.state.cameraPermission) {
-      case PermissionState.Unknown:
+      case PermissionStatus.UNDETERMINED:
         return <Text>Requesting for camera permission.</Text>;
 
-      case PermissionState.Denied:
+      case PermissionStatus.DENIED:
         return <Text>No access to the camera.</Text>;
 
-      case PermissionState.Granted:
+      case PermissionStatus.GRANTED:
         return (
           <View style={{ flex: 1 }}>
             <Text

--- a/src/demoScreens/BarCodeScannerScreen.tsx
+++ b/src/demoScreens/BarCodeScannerScreen.tsx
@@ -5,7 +5,7 @@ import { StyleSheet, Text, View } from "react-native";
 interface Props {}
 
 interface State {
-  cameraPermission: PermissionStatus;
+  cameraPermission: PermissionStatus | undefined;
   scannedText: string;
 }
 
@@ -22,17 +22,17 @@ export class BarCodeScannerScreen extends React.Component<Props, State> {
   public async componentDidMount() {
     const { status } = await BarCodeScanner.requestPermissionsAsync();
     this.setState({
-      cameraPermission:
-        status === PermissionStatus.GRANTED
-          ? PermissionStatus.GRANTED
-          : PermissionStatus.DENIED,
+      cameraPermission: status,
     });
   }
 
   public render(): ReactNode {
     switch (this.state.cameraPermission) {
-      case PermissionStatus.UNDETERMINED:
+      case undefined:
         return <Text>Requesting for camera permission.</Text>;
+
+      case PermissionStatus.UNDETERMINED:
+        return <Text>Could not determine if camera could be accessed.</Text>;
 
       case PermissionStatus.DENIED:
         return <Text>No access to the camera.</Text>;

--- a/src/demoScreens/CameraScreen.tsx
+++ b/src/demoScreens/CameraScreen.tsx
@@ -1,6 +1,5 @@
 import { Camera } from "expo-camera";
 import { CameraType } from "expo-camera/build/Camera.types";
-import * as Permissions from "expo-permissions";
 import React, { Component } from "react";
 import { Text, TouchableOpacity, View } from "react-native";
 
@@ -22,7 +21,7 @@ export class CameraScreen extends Component<Props, State> {
   }
 
   public async componentDidMount() {
-    const { status } = await Permissions.askAsync(Permissions.CAMERA);
+    const { status } = await Camera.requestPermissionsAsync();
 
     this.setState({
       hasPermissionToCamera: status === "granted",

--- a/src/demoScreens/CameraScreen.tsx
+++ b/src/demoScreens/CameraScreen.tsx
@@ -1,4 +1,4 @@
-import { Camera } from "expo-camera";
+import { Camera, PermissionStatus } from "expo-camera";
 import { CameraType } from "expo-camera/build/Camera.types";
 import React, { Component } from "react";
 import { Text, TouchableOpacity, View } from "react-native";
@@ -15,7 +15,7 @@ export class CameraScreen extends Component<Props, State> {
     super(props);
 
     this.state = {
-      cameraType: "back",
+      cameraType: CameraType.back,
       hasPermissionToCamera: undefined,
     };
   }
@@ -24,7 +24,7 @@ export class CameraScreen extends Component<Props, State> {
     const { status } = await Camera.requestPermissionsAsync();
 
     this.setState({
-      hasPermissionToCamera: status === "granted",
+      hasPermissionToCamera: status === PermissionStatus.GRANTED,
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5806,11 +5806,6 @@ expo-local-authentication@~11.0.2:
     "@expo/config-plugins" "^1.0.18"
     invariant "^2.2.4"
 
-expo-permissions@~12.0.1:
-  version "12.0.1"
-  resolved "https://registry.yarnpkg.com/expo-permissions/-/expo-permissions-12.0.1.tgz#5163c00d991bf565bf987354611628c298ddd0c4"
-  integrity sha512-TtypNPPLG4SdVEKBlrArLLZIyhlhE+3B4dhz2HaY1Mve2rcvKE0C7z/e1WoUVU8+LgcdKoNGwg/wRVeCkxeEhg==
-
 expo-pwa@0.0.82:
   version "0.0.82"
   resolved "https://registry.yarnpkg.com/expo-pwa/-/expo-pwa-0.0.82.tgz#9e84995672e7abd340eaab4a7081c8d29577074a"


### PR DESCRIPTION
- Fix a bug in the bar code scanner that prevented it from showing the scanned codes. 😬
- Remove the deprecated `expo-permissions`.
- Allow scanning all supported code types.